### PR TITLE
FilePropertyManagement suggestions

### DIFF
--- a/docs/FilePropertyManagement.md
+++ b/docs/FilePropertyManagement.md
@@ -106,7 +106,22 @@ With the above configuration, zAppBuild will import these properties and set the
 
 You can view a sample properties file, [epsmlist.cbl.properties](../samples/MortgageApplication/properties/epsmlist.cbl.properties), within the MortgageApplication sample.
 
-Please note that overriding the same build property using the DBB file property syntax using a group filter, may cause contingencies.
+**Note:** Overrides for a given build property should be managed either via the DBB file property path syntax or in the individual property files, but not both at the same time (as this can cause unpredictable behavior). The following example shows how both approaches for defining file properties can be combined to specify a set of build properties for the same source file:
+
+- Example using the DBB file property path syntax and individual property files to define build properties for a source file named `app/cobol/AB123456.cbl`:
+  - You can use the DBB file property path syntax to define a file property for a group of files. The below defines the `deployType` for all source files in the folder cobol beginning with `AB*` to be `BATCHLOAD`:
+
+    ```properties
+    cobol_deployType = BATCHLOAD :: **/cobol/AB*.cbl
+    ```
+
+  - At the same time, you can define an individual file property file for `app/cobol/AB123456.cbl` with the following *different* build property:
+
+    ```properties
+    cobol_compileParms = LIB,SOURCE
+    ```
+
+  - During the build, the file `app/cobol/AB123456.cbl` will have the `deployType` `BATCHLOAD` and the COBOL compile parameters `LIB` and `SOURCE`.
 
 ### Language Definition Mapping
 

--- a/docs/FilePropertyManagement.md
+++ b/docs/FilePropertyManagement.md
@@ -2,37 +2,37 @@
 
 ## Table of contents
 
-- [File Property Management](#file-property-management)
-  - [Table of contents](#table-of-contents)
-  - [Introduction](#introduction)
-  - [Overriding build properties with DBB and zAppBuild](#overriding-build-properties-with-dbb-and-zappbuild)
-  - [Default properties](#default-properties)
-  - [Overriding properties](#overriding-properties)
-    - [DBB file properties](#dbb-file-properties)
-    - [Individual File Property](#individual-file-property)
-    - [Language Definition Mapping](#language-definition-mapping)
+- [Introduction](#introduction)
+- [Overriding build properties with DBB and zAppBuild](#overriding-build-properties-with-dbb-and-zappbuild)
+- [Default properties](#default-properties)
+- [Overriding properties](#overriding-properties)
+- [DBB file properties](#dbb-file-properties)
+- [Individual File Property](#individual-file-property)
+- [Language Definition Mapping](#language-definition-mapping)
 
 ## Introduction
 
-Building mainframe application programs requires configuring various parameters and options for the different build steps, such as the pre-compile, compile, or link-edit step. Additionally, an application can contain COBOL programs that need to be link edited with the option `NCAL` or without the option `NCAL` for different purposes. An override may be required for any build parameter for the various build steps like compile parameters, bind parameters, link edit parameters, and so on.
+Building mainframe application programs requires configuring various parameters and options for the different build steps, such as the pre-compile, compile, or link-edit step. For example, an application can contain COBOL programs that need to be link edited with the option `NCAL` or without the option `NCAL` for different purposes. An override may be required for any build parameter for the various build steps like compile parameters, bind parameters, link edit parameters, and so on.
 
-In existing mainframe toolchains, this customization is performed by assigning a type to the application artifact. This *type* is often used to specify the build parameters and options for the entire **subgroup** of application artifacts. Obviously, it allows that an application program might have some individual overrides as well.
+In existing mainframe toolchains, this customization is performed by assigning a type to the application artifact. This *type* is often used to specify the build parameters and options for an entire **subgroup** of application artifacts. Additionally, it allows that an application program might have some individual overrides as well.
 
-Generally, think of these settings as either as a default value or as an override of the build parameter for an application artifact.
+Generally, each build parameter for an application artifact will either have a default value or an override of the default value.
 
 ## Overriding build properties with DBB and zAppBuild
 
-Dependency Based Build comes with its own [APIs](https://www.ibm.com/docs/api/v1/content/SS6T76_2.0.0/javadoc/index.html) to manage build properties, which extends the standard key-value pair strategy of *java.util.Properties*. DBB refers to the term *File properties* to allow overriding the corresponding default build properties using the DBB file property path syntax. See [IBM DBB Docs - Build properties](https://www.ibm.com/docs/en/dbb/2.0.0?topic=apis-build-properties#file-properties) for more details.
+Dependency Based Build comes with its own [APIs](https://www.ibm.com/docs/api/v1/content/SS6T76_2.0.0/javadoc/index.html) to manage build properties, which extend the standard key-value pair strategy of *java.util.Properties*. DBB refers to the term *File properties* to allow overriding the corresponding default build properties using the DBB file property path syntax. See [IBM DBB Docs - Build properties](https://www.ibm.com/docs/en/dbb/latest?topic=apis-build-properties#file-properties) for more details about this syntax.
 
-zAppBuild's implementation supports overriding the majority of build properties. The full list can be viewed at [application-conf/README.md](../samples/application-conf/README.md).
+The zAppBuild framework supports overriding the majority of DBB build properties. The full list can be viewed at [application-conf/README.md](../samples/application-conf/README.md).
 
 zAppBuild leverages DBB's API and allows you to define build parameters on three different levels for each language script:
 
-  1. General defaults in corresponding the language property files - for example, defining the compile options for building COBOL programs in [application-conf/Cobol.properties](../samples/application-conf/Cobol.properties). Property keys make use of a language prefix, for instance for COBOL programs this is `cobol_`.
-  2. A group definition, to overriding the default by specifying using DBB's file property syntax using a pattern filter; or through a mapping to a language definition file to override the defaults, like [application-conf/languageDefinitionMapping.properties](../samples/MortgageApplication/application-conf/languageDefinitionMapping.properties). 
-  3. An individual file-level definition to override a single parameter leveraging Dependency Based Builds file properties syntax using [application-conf/file.properties](../samples/application-conf/file.properties) or multiple parameters for a specific file using the individual property file, like [epsmlist.cbl.properties](../samples/MortgageApplication/properties/epsmlist.cbl.properties).
+1. General defaults in the corresponding language property files: For example, you can define the compile options for building COBOL programs in [application-conf/Cobol.properties](../samples/application-conf/Cobol.properties). Property keys make use of a language prefix; for instance, COBOL property keys are prefixed with `cobol_`.
+2. A group definition that overrides the default in one of two ways:
+   - By using DBB's file property syntax and specifying the application artifact group via a pattern filter on the path name(s)
+   - By mapping to a language definition file to override the defaults, such as in [application-conf/languageDefinitionMapping.properties](../samples/MortgageApplication/application-conf/languageDefinitionMapping.properties)
+3. An individual file-level definition to override a single parameter via Dependency Based Build's file properties syntax using [application-conf/file.properties](../samples/application-conf/file.properties) or multiple parameters for a specific file using the individual property file. For example: [epsmlist.cbl.properties](../samples/MortgageApplication/properties/epsmlist.cbl.properties).
 
-zAppBuild comes with various strategies that can be combined via an order of precedence. The following table summarizes the strategies for overriding file properties from highest to lowest precedence:
+zAppBuild comes with various build property strategies that can be combined via an order of precedence. The following table summarizes the strategies for overriding file properties from highest to lowest precedence:
 
 ||Strategy|Use case|
 |-|-|-|
@@ -43,21 +43,21 @@ zAppBuild comes with various strategies that can be combined via an order of pre
 
 To understand the order of precedence, think of this as a merge of the property configurations. For example, if both individual file properties and a language definition mapping are configured for a file, then the properties defined through the individual file property definition take precedence, but are also merged with other properties defined by the language definition mapping and the default properties.
 
-
+The following sections explain these build property strategies in more detail.
 
 ## Default properties
 
-Default properties can be set in the corresponding language properties file.  For example, the COBOL file properties can be set in [application-conf/Cobol.properties](../samples/application-conf/Cobol.properties), while the Assembler file properties can be set in [application-conf/Assembler.properties](../samples/application-conf/Assembler.properties), and so on.
+Default properties can be set in the corresponding language properties file. For example, the COBOL file properties can be set in [application-conf/Cobol.properties](../samples/application-conf/Cobol.properties), while the Assembler file properties can be set in [application-conf/Assembler.properties](../samples/application-conf/Assembler.properties), and so on.
 
-zAppBuild is currently proposing to store these properties within the application repository and let the application team have control over these files. If you are looking for a more centralized way to manage the default options for all applications, you can move these definitions into the zAppBuild build framework itself by either merging them into the appropriate language property file under [build-conf](../build-conf/) or store them in a separate directory within zAppBuild itself and leverage the `applicationConfRootDir` property in [build-conf/build.propertiees](../build-conf/build.properties).
+zAppBuild is currently proposing to store these properties within the application repository and let the application team have control over these files. If you are looking for a more centralized way to manage the default options for all applications, you can move these definitions into the zAppBuild build framework itself by either merging them into the appropriate language property file under [build-conf](../build-conf/), or by storing them in a separate directory within zAppBuild itself and leveraging the `applicationConfRootDir` property in [build-conf/build.propertiees](../build-conf/build.properties).
 
 ## Overriding properties
 
-The following section describes the various strategies to override the default value. The DBB file property syntax is the most commonly used approach within the zAppBuild samples. Two alternate approaches to override build properties are implemented in zAppBuild to serve the different needs and requirement to simplify the adoption of zAppBuild by either leveraging an individual properties file per application artifact or by defining a language definition mapping.
+The following section describes the various strategies to override default build property values. The DBB file property syntax is the most commonly used approach within the zAppBuild samples. Two alternate approaches to override build properties are implemented in zAppBuild to serve the different use cases, and can be used to simplify the adoption of zAppBuild by either leveraging an individual properties file per application artifact, or by defining a language definition mapping.
 
 ### DBB file properties
 
-The most common way to override a single build parameter, makes use of the DBB file property syntax.
+The most common way to override a single build parameter makes use of the [DBB file property syntax](https://www.ibm.com/docs/en/dbb/latest?topic=apis-build-properties#file-properties).
 
 For example, to use a DBB file property to override the default COBOL compile parameters for build artifact `MortgageApplication/cobol/epsnbrvl.cbl`, follow the DBB file property syntax in `file.properties`, which is the default property file for configuring file property overrides:
 
@@ -65,13 +65,13 @@ For example, to use a DBB file property to override the default COBOL compile pa
 cobol_compileParms=LIB,SOURCE :: **/cobol/epsnbrvl.cbl
 ```
 
-For merging, rather than overriding, the property value of this file-level override with the default setting, you can specify the following syntax:
+For merging the property value of this file-level override with the default COBOL compile parameters (rather than overriding them), you can specify the following syntax:
 
 ```properties
 cobol_compileParms=${cobol_compileParms},SOURCE :: **/cobol/epsnbrvl.cbl
 ```
 
-The file property path syntax also allows you to override the a build parameter for a set of files using wildcards. For example, let's assume that you are storing all CICS modules in `cobol_cics` subfolder. Using the following sample will ensure that the file flag `isCICS` is set to `true` for all COBOL files in this subfolder with the file extension `*.cbl`. However, it is recommended not to store information about the build configuration within the layout of folders, because an update would require to move files into different directories.
+The file property path syntax also allows you to override the a build parameter for a set of files using wildcards. For example, let's assume that you are storing all CICS modules in the `cobol_cics` subfolder. Using the following sample will ensure that the file flag `isCICS` is set to `true` for all COBOL files in this subfolder with the file extension `*.cbl`. However, it is recommended not to store information about the build configuration within the layout of folders, because an update would require to move files into different directories.
 
 ```properties
 isCICS = true :: **/cobol_cics/*.cbl
@@ -83,17 +83,17 @@ The MortgageApplication sample contains a good sample of how the DBB file proper
 
 The approach of using the DBB file property syntax might become cumbersome if you want to manage multiple property overrides for a given application artifact.
 
-This strategy is changing the way of specifying the properties by allowing to manage multiple property overrides together  within an **individual properties file** for a given build artifact. It focusses on the build artifact rather than the build property.
+The individual file property strategy changes the way of specifying the properties by allowing you to manage multiple property overrides together within an **individual properties file** for a given build artifact. It focuses on the build artifact rather than the build property.
 
-The functionality to load properties from an individual properties file can be activated by setting the configuration property `loadFileLevelProperties` in `application-conf/application.properties` file to `true`. To enable this feature for a specific file or a subset of application artifacts, leverage a DBB file property in `application-conf/file.properties` file to set `loadFileLevelProperties` to `true`. The below sample configures zAppBuild to look for an individual properties file for all the programs starting with `eps` and `lga` in `application-conf/file.properties` file.
+The functionality to load properties from an individual properties file can be activated by setting the configuration property `loadFileLevelProperties` in the `application-conf/application.properties` file to `true`. To enable this feature for a specific file or a subset of application artifacts, use the DBB file property syntax in `application-conf/file.properties` file to set `loadFileLevelProperties` to `true`. The following sample configures zAppBuild to look for an individual properties file for all the programs starting with `eps` and `lga` in `application-conf/file.properties` file.
 
 ```properties
 loadFileLevelProperties = true :: **/cobol/eps*.cbl, **/cobol/lga*.cbl` 
 ```
 
-Individual properties files are resolved using the pattern `<propertyFilePath directory>/<sourceFile>.<propertyFileExtension>`. The `propertyFilePath` and `propertyFileExtension` can be customized in [application-conf/application.properties](../samples/MortgageApplication/application-conf/application.properties). For example, for the source file `epsmlist.cbl`, the process searches for a file in the propertyFilePath directory. If no corresponding property file is found, the build will use the default build values or, if any file properties were defined using the DBB file property path syntax or an alternate approach, then the build will use those.
+Individual properties files are resolved using the pattern `<propertyFilePath directory>/<sourceFile>.<propertyFileExtension>`. The `propertyFilePath` and `propertyFileExtension` can be customized in [application-conf/application.properties](../samples/MortgageApplication/application-conf/application.properties). For example, for the source file `epsmlist.cbl`, the process searches for a file in the defined `propertyFilePath` directory. If no corresponding property file is found, the build will use the default build values or, if any file properties were defined using the DBB file property path syntax or an alternate approach, then the build will use those.
 
-Once the `loadFileLevelProperties` property functionality is enabled, create a property file for each application artifact for which the Individual File Properties need to be defined. For example: to override build parameters for file `epsmlist.cbl` create the properties file `epsmlist.cbl.properties` in the defined folder. The name of the properties file needs to have the entire file name including the extension i.e. the properties file for `epsmlist.cbl` needs to be `epsmlist.cbl.properties`.
+Once the `loadFileLevelProperties` property functionality is enabled, create a property file for each application artifact for which individual file properties need to be defined. For example, to override build parameters for the file `epsmlist.cbl`, create the properties file `epsmlist.cbl.properties` in the defined `propertyFilePath` folder. The name of the properties file needs to have the entire source file name including the extension, e.g. the properties file for `epsmlist.cbl` needs to be `epsmlist.cbl.properties`.
 
 The individual properties file allows you to define multiple build properties using the standard property syntax; for instance, in `epsmlist.cbl.properties`, you can define the following properties:
 
@@ -106,28 +106,28 @@ With the above configuration, zAppBuild will import these properties and set the
 
 You can view a sample properties file, [epsmlist.cbl.properties](../samples/MortgageApplication/properties/epsmlist.cbl.properties), within the MortgageApplication sample.
 
-Please note that overriding the same build property using the DBB file property syntax using a group filter, may cause contingencies. 
+Please note that overriding the same build property using the DBB file property syntax using a group filter, may cause contingencies.
 
 ### Language Definition Mapping
 
-An alternative way to define build properties for a **subgroup of files** is leveraging a mapping approach. Rather than specifying individual parameters or properties for an individual application artifact, the application artifact is mapped to a language definition, which can define multiple build parameters at a central properties file. All mapped application artifacts will inherit the defined build parameters. 
+An alternative way to define build properties for a **subgroup of files** is leveraging a mapping approach. Rather than specifying individual parameters or properties for an individual application artifact, the application artifact is mapped to a language definition, which can then define multiple build parameters in a central properties file. All mapped application artifacts will inherit the defined build parameters.
 
 This approach requires:
 
-- a mapping of application artifact to a language definition
+- a mapping of the application artifact(s) to a language definition
 - a property file for defining the build parameters for each language definition
 
-The Language Definition Property approach can be enabled by setting the property `loadLanguageDefinitionProperties` in `application-conf/application.properties` file to `true`. To enable this option for a specific file or a set of files the property, use the DBB file property syntax and set  `loadLanguageDefinitionProperties` set as `true` in the `application-conf/file.properties` file. Below is a sample to enable Language Definition Property for all programs starting with `eps` and `lga` in `application-conf/file.properties` file:
+The Language Definition Property approach can be enabled by setting the property `loadLanguageDefinitionProperties` in the `application-conf/application.properties` file to `true`. To enable this option for a specific file or a set of files, use the DBB file property syntax and set  `loadLanguageDefinitionProperties` to `true` in the `application-conf/file.properties` file. Below is a sample to enable Language Definition Mapping for all programs starting with `eps` and `lga` via the `application-conf/file.properties` file:
 
 ```properties
 loadLanguageDefinitionProperties = true :: **/cobol/eps*.cbl, **/cobol/lga*.cbl
 ```
 
-The Language Definition Property files need to be created in the `build-conf` folder. You can now specify file properties which support the overriding in the Language Definition Property file. You can create multiple Language Definition Property files under `build-conf` folder to serve different variations / types. A sample Language Definition Property file can be found at [langDefProps01.properties](../build-conf/langDefProps01.properties).  
+The Language Definition Property files need to be created in the `build-conf` folder. This will allow you to define file properties that support overriding in the Language Definition Property file. You can create multiple Language Definition Property files under `build-conf` folder to serve different variations or types. A sample Language Definition Property file can be found at [langDefProps01.properties](../build-conf/langDefProps01.properties).  
 
-The language definition property file allows you to centrally specify build properties for a the group of mapped application artifacts. All mapped files will inherit the build properties. However, in the case of combining the language definition mapping with an individual property file override, the settings in the individual property file will take precedence. 
+The language definition property file allows you to centrally specify build properties for the group of mapped application artifacts. All mapped files will inherit the build properties. However, in the case of combining the language definition mapping with an individual property file override, the settings in the individual property file will take precedence.
 
-In the following sample language definition, *langDefProps01.properties* is overriding the default COBOL compile parameters,  the file flag isCICS and the linkEdit statement:
+In the following sample language definition, *langDefProps01.properties* is overriding the default COBOL compile parameters (`cobol_compileParms`), the file flag `isCICS`, and the linkEdit statement (`cobol_linkEditStream`):
 
 ```properties
 cobol_compileParms=LIB,SOURCE
@@ -135,16 +135,15 @@ isCICS = true
 cobol_linkEditStream=    INCLUDE OBJECT(@{member})\n    INCLUDE SYSLIB(CUSTOBJ)
 ```
 
-To map files to the language definition, create a `languageDefinitionMapping.properties` file in the `application-conf` folder of your application repo and specify the language definition mapping. For example
+To map files to the language definition, create a `languageDefinitionMapping.properties` file in the `application-conf` folder of your application repo and specify the language definition mapping.
 
-```properties
-epsnbrvl.cbl=langDefProps01
-epsmlist.cbl=langDefProps01
-```
+- For example, the following snippet in `languageDefinitionMapping.properties` maps both files `epsnbrvl.cbl` and `epsmlist.cbl` to use the `build-conf/langDefProps01.properties` for Language Definition Property overrides.:
 
-maps both files `epsnbrvl.cbl` and `epsmlist.cbl` to use the `build-conf/langDefProps01.properties` for Language Definition Property overrides.
+  ```properties
+  epsnbrvl.cbl=langDefProps01
+  epsmlist.cbl=langDefProps01
+  ```
 
 See [languageDefinitionMapping.properties](../samples/MortgageApplication/application-conf/languageDefinitionMapping.properties) for a sample language definition mapping file.
 
-The implementation again leverages DBB's file property concept to define these settings only for the mapped files.
-
+This Language Definition Mapping implementation again leverages DBB's file property concept to define these settings only for the mapped files.

--- a/docs/FilePropertyManagement.md
+++ b/docs/FilePropertyManagement.md
@@ -22,7 +22,7 @@ Generally, each build parameter for an application artifact will either have a d
 
 Dependency Based Build comes with its own [APIs](https://www.ibm.com/docs/api/v1/content/SS6T76_2.0.0/javadoc/index.html) to manage build properties, which extend the standard key-value pair strategy of *java.util.Properties*. DBB refers to the term *File properties* to allow overriding the corresponding default build properties using the DBB file property path syntax. See [IBM DBB Docs - Build properties](https://www.ibm.com/docs/en/dbb/latest?topic=apis-build-properties#file-properties) for more details about this syntax.
 
-The zAppBuild framework supports overriding the majority of DBB build properties. The full list can be viewed at [application-conf/README.md](../samples/application-conf/README.md).
+zAppBuild supports overriding the majority of build properties defined within its framework. The full list can be viewed at [application-conf/README.md](../samples/application-conf/README.md).
 
 zAppBuild leverages DBB's API and allows you to define build parameters on three different levels for each language script:
 

--- a/docs/FilePropertyManagement.md
+++ b/docs/FilePropertyManagement.md
@@ -65,19 +65,21 @@ For example, to use a DBB file property to override the default COBOL compile pa
 cobol_compileParms=LIB,SOURCE :: **/cobol/epsnbrvl.cbl
 ```
 
-For merging the property value of this file-level override with the default COBOL compile parameters (rather than overriding them), you can specify the following syntax:
+For merging the property values of this file-level override with the default COBOL compile parameters (rather than just overriding them), you can specify the following syntax:
 
 ```properties
 cobol_compileParms=${cobol_compileParms},SOURCE :: **/cobol/epsnbrvl.cbl
 ```
 
-The file property path syntax also allows you to override the a build parameter for a set of files using wildcards. For example, let's assume that you are storing all CICS modules in the `cobol_cics` subfolder. Using the following sample will ensure that the file flag `isCICS` is set to `true` for all COBOL files in this subfolder with the file extension `*.cbl`. However, it is recommended not to store information about the build configuration within the layout of folders, because an update would require to move files into different directories.
+The file property path syntax also allows you to override the a build parameter for a set of files using wildcards. For example, let's assume that you are storing all CICS modules in the `cobol_cics` subfolder. Using the following sample will ensure that the file flag `isCICS` is set to `true` for all COBOL files in this subfolder with the file extension `*.cbl`.
 
 ```properties
 isCICS = true :: **/cobol_cics/*.cbl
 ```
 
-The MortgageApplication sample contains a good sample of how the DBB file property can be used. Typically, these overrides are defined in [application-conf/file.properties](../samples/MortgageApplication/application-conf/file.properties).
+- **Note:** We do not recommend organizing the layout of repository folders/files based on build property management, because future updates to the build information of a file could require it to be moved into different folders. Instead, we recommend that the repository's folder layout represent the functional context of the files.
+
+The MortgageApplication sample contains a good example of how the DBB file property can be used. Typically, these overrides are defined in [application-conf/file.properties](../samples/MortgageApplication/application-conf/file.properties).
 
 ### Individual File Property
 

--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -39,44 +39,9 @@ skipImpactCalculationList=
 ###############################################################
 # Build Property management
 ###############################################################
-# 
 # zAppBuild allows you to manage default properties and file properties:
-#
-# - Default build properties are defined in the /build-conf and /application-conf property files (e.g. Cobol.properties)
-#  
-# - File properties override corresponding default build properties, and are defined through one of two methods:
-#   - Overwrites for groups or individual files 
-#     - Typically defined in file.properties using the DBB file property path syntax
-#     - See: https://www.ibm.com/docs/en/dbb/1.1.0?topic=scripts-how-organize-build-script#file-properties
-#   - Overwrites for an individual file
-#     - Defined in an individual property file located in a configurable subfolder (e.g. properties/epsmlist.cbl.properties)
-#
-# A typical scenario for using zAppBuild's capability to set build properties for an individual source file via a corresponding
-# individual property file is to overwrite compile or link options. This approach might help ease the migration of properties
-# from the previous build system.
-#
-# Individual property files are resolved using the pattern <propertyFilePath directory>/<sourceFile>.<propertyFileExtension>. For example,
-#  for the source file epsmlist.cbl, the process searches for a file in the propertyFilePath directory
-#  with the name epsmlist.cbl.properties.
-#  If no corresponding property file is found, the build will use the default build values. (Or, if any file properties were defined
-#  using the DBB file property path syntax, then the build will use those.)
-#
-# Note: Overwrites for a specific build property should be managed either via the file property path syntax or
-#  in the individual property files, but not both. The following example shows how both approaches for defining
-#  file properties can be combined to specify a set of build properties for the same source file:
-#
-# ### Example: Using the file property path syntax and individual property files to define build properties for a source file named app/cobol/AB123456.cbl
-# - You can use the file property path syntax to define a file property for a group of files. The below defines the deployType for
-#  all source files in the folder cobol beginning with AB* to be BATCHLOAD:
-#
-#  cobol_deployType = BATCHLOAD :: **/cobol/AB*.cbl
-#
-# - At the same time, you can define an individual file property file for app/cobol/AB123456.cbl with the following build property:
-#  
-#  cobol_compileParms = LIB,SOURCE
-# 
-# - During the build, the file app/cobol/AB123456.cbl will have the deployType BATCHLOAD and the COBOL compile parameters LIB and SOURCE.
-# ### End example ###
+# - Documentation on how to override corresponding default build properties can be found at:
+#   https://github.com/IBM/dbb-zappbuild/docs/FilePropertyManagement.md
 
 # ### Properties to enable and configure build property overwrites using individual property files
 

--- a/samples/MortgageApplication/application-conf/languageDefinitionMapping.properties
+++ b/samples/MortgageApplication/application-conf/languageDefinitionMapping.properties
@@ -6,4 +6,4 @@
 epsnbrvl.cbl=langDefProps01
 epsmpmt.cbl=langDefProps01
 
-# Insert all the (file = language definition properties) mapping here!!!
+# Insert all the (file = language definition properties) mapping here!

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -58,44 +58,9 @@ jobCard=
 ###############################################################
 # Build Property management
 ###############################################################
-# 
 # zAppBuild allows you to manage default properties and file properties:
-#
-# - Default build properties are defined in the /build-conf and /application-conf property files (e.g. Cobol.properties)
-#  
-# - File properties override corresponding default build properties, and are defined through one of two methods:
-#   - Overwrites for groups or individual files 
-#     - Typically defined in file.properties using the DBB file property path syntax
-#     - See: https://www.ibm.com/docs/en/dbb/1.1.0?topic=scripts-how-organize-build-script#file-properties
-#   - Overwrites for an individual file
-#     - Defined in an individual property file located in a configurable subfolder (e.g. properties/epsmlist.cbl.properties)
-#
-# A typical scenario for using zAppBuild's capability to set build properties for an individual source file via a corresponding
-# individual property file is to overwrite compile or link options. This approach might help ease the migration of properties
-# from the previous build system.
-#
-# Individual property files are resolved using the pattern <propertyFilePath directory>/<sourceFile>.<propertyFileExtension>. For example,
-#  for the source file epsmlist.cbl, the process searches for a file in the propertyFilePath directory
-#  with the name epsmlist.cbl.properties.
-#  If no corresponding property file is found, the build will use the default build values. (Or, if any file properties were defined
-#  using the DBB file property path syntax, then the build will use those.)
-#
-# Note: Overwrites for a specific build property should be managed either via the file property path syntax or
-#  in the individual property files, but not both. The following example shows how both approaches for defining
-#  file properties can be combined to specify a set of build properties for the same source file:
-#
-# ### Example: Using the file property path syntax and individual property files to define build properties for a source file named app/cobol/AB123456.cbl
-# - You can use the file property path syntax to define a file property for a group of files. The below defines the deployType for
-#  all source files in the folder cobol beginning with AB* to be BATCHLOAD:
-#
-#  cobol_deployType = BATCHLOAD :: **/cobol/AB*.cbl
-#
-# - At the same time, you can define an individual file property file for app/cobol/AB123456.cbl with the following build property:
-#  
-#  cobol_compileParms = LIB,SOURCE
-# 
-# - During the build, the file app/cobol/AB123456.cbl will have the deployType BATCHLOAD and the COBOL compile parameters LIB and SOURCE.
-# ### End example ###
+# - Documentation on how to override corresponding default build properties can be found at:
+#   https://github.com/IBM/dbb-zappbuild/docs/FilePropertyManagement.md
 
 # ### Properties to enable and configure build property overwrites using individual property files
 

--- a/samples/application-conf/languageDefinitionMapping.properties
+++ b/samples/application-conf/languageDefinitionMapping.properties
@@ -6,4 +6,4 @@
 epsnbrvl.cbl=langDefProps01
 epsmpmt.cbl=langDefProps01
 
-# Insert all the file ==> language definition properties mapping here!!!
+# Insert all the file ==> language definition properties mapping here!


### PR DESCRIPTION
This PR contains copyedit suggestions for `FilePropertyManagement.md`, and also moves the information from `application.properties`' long Build Property Management comment into FilePropertyManagement.md while providing a link to the new documentation.