### PR TITLE
Standardize terminology for individual artifact properties file

### DIFF
--- a/docs/FilePropertyManagement.md
+++ b/docs/FilePropertyManagement.md
@@ -7,8 +7,8 @@
 - [Default properties](#default-properties)
 - [Overriding properties](#overriding-properties)
 - [DBB file properties](#dbb-file-properties)
-- [Individual File Property](#individual-file-property)
-- [Language Definition Mapping](#language-definition-mapping)
+- [Individual artifact properties file](#individual-artifact-properties-file)
+- [Language definition mapping](#language-definition-mapping)
 
 ## Introduction
 
@@ -32,18 +32,18 @@ zAppBuild leverages DBB's API and allows you to define build parameters on three
    - By mapping to a language definition file to override the defaults, such as in [application-conf/languageDefinitionMapping.properties](../samples/MortgageApplication/application-conf/languageDefinitionMapping.properties)
 3. An individual file-level definition that overwrites the general default in one of two ways:
    - By using DBB's file properties syntax in [application-conf/file.properties](../samples/application-conf/file.properties), and specifying the application artifact's path as the file path pattern
-   - By specifying multiple parameters for a specific file using the individual property file. For example: [epsmlist.cbl.properties](../samples/MortgageApplication/properties/epsmlist.cbl.properties).
+   - By specifying multiple parameters for a specific file using the individual artifact properties file. For example: [epsmlist.cbl.properties](../samples/MortgageApplication/properties/epsmlist.cbl.properties).
 
 zAppBuild comes with various build property strategies that can be combined via an order of precedence. The following table summarizes the strategies for overriding file properties from highest to lowest precedence:
 
 |Precedence|Strategy|Use case|Implementation|
 |-|-|-|-|
-|1.|Individual file properties|Override one or multiple build parameters for individual files|DBB file property defining an override for the specific file[^1]|
+|1.|Individual artifact properties file|Override one or multiple build parameters for individual files|DBB file property defining an override for the specific file[^1]|
 |2.|Language definition mapping|Override and define one or multiple build parameters for a group of mapped application artifacts|DBB file property defining an override for the specific file(s)[^1]|
 |3.|DBB file properties|Override a single build parameter for individual files or a grouped list of application artifacts|DBB file property defining an override for the specific[^1]  or grouped list[^2] of application artifacts|
 |4.|Default properties|General build properties used when no overrides are defined|Build property defining the default value for all files|
 
-To understand the order of precedence, think of this as a merge of the property configurations. For example, if both individual file properties and a language definition mapping are configured for a file, then the properties defined through the individual file property definition take precedence, but are also merged with other properties defined by the language definition mapping and the default properties.
+To understand the order of precedence, think of this as a merge of the property configurations. For example, if both an individual artifact properties file and a language definition mapping are configured for a file, then the properties defined through the individual artifact properties file take precedence, but are also merged with other properties defined by the language definition mapping and the default properties.
 
 The following sections explain these build property strategies in more detail.
 
@@ -58,7 +58,7 @@ By default, zAppBuild applies the properties stored in the [application-conf](..
 
 ## Overriding properties
 
-The following section describes the various strategies to override default build property values. The DBB file property syntax is the most commonly used approach within the zAppBuild samples. Two alternate approaches to override build properties are implemented in zAppBuild to serve the different use cases, and can be used to simplify the adoption of zAppBuild by either leveraging an individual properties file per application artifact, or by defining a language definition mapping.
+The following section describes the various strategies to override default build property values. The DBB file property syntax is the most commonly used approach within the zAppBuild samples. Two alternate approaches to override build properties are implemented in zAppBuild to serve the different use cases, and can be used to simplify the adoption of zAppBuild by either leveraging an individual artifact properties file per application artifact, or by defining a language definition mapping.
 
 ### DBB file properties
 
@@ -86,23 +86,23 @@ isCICS = true :: **/cobol_cics/*.cbl
 
 The MortgageApplication sample contains a good example of how the DBB file property can be used. Typically, these overrides are defined in [application-conf/file.properties](../samples/MortgageApplication/application-conf/file.properties).
 
-### Individual File Property
+### Individual artifact properties file
 
 The approach of using the DBB file property syntax might become cumbersome if you want to manage multiple property overrides for a given application artifact.
 
-The individual file property strategy changes the way of specifying the properties by allowing you to manage multiple property overrides together within an **individual properties file** for a given build artifact. It focuses on the build artifact rather than the build property.
+The "individual artifact properties file" strategy changes the way of specifying the properties by allowing you to manage multiple property overrides together within an individual properties file for a given build artifact. It centers around the build artifact rather than the build property.
 
-The functionality to load properties from an individual properties file can be activated by setting the configuration property `loadFileLevelProperties` in the `application-conf/application.properties` file to `true`. To enable this feature for a specific file or a subset of application artifacts, use the DBB file property syntax in `application-conf/file.properties` file to set `loadFileLevelProperties` to `true`. The following sample configures zAppBuild to look for an individual properties file for all the programs starting with `eps` and `lga` in `application-conf/file.properties` file.
+The functionality to load properties from an individual artifact properties file can be activated by setting the configuration property `loadFileLevelProperties` in the `application-conf/application.properties` file to `true`. To enable this feature for a specific artifact or a subset of application artifacts, use the DBB file property syntax in `application-conf/file.properties` to set `loadFileLevelProperties` to `true`. The following snippet from a sample `application-conf/file.properties` file configures zAppBuild to look for an individual artifact properties file for all the programs starting with `eps` and `lga`:
 
 ```properties
 loadFileLevelProperties = true :: **/cobol/eps*.cbl, **/cobol/lga*.cbl` 
 ```
 
-Individual properties files are resolved using the pattern `<propertyFilePath directory>/<sourceFile>.<propertyFileExtension>`. The `propertyFilePath` and `propertyFileExtension` can be customized in [application-conf/application.properties](../samples/MortgageApplication/application-conf/application.properties). For example, for the source file `epsmlist.cbl`, the process searches for a file in the defined `propertyFilePath` directory. If no corresponding property file is found, the build will use the default build values or, if any file properties were defined using the DBB file property path syntax or an alternate approach, then the build will use those.
+Individual artifact properties files are resolved using the pattern `<propertyFilePath directory>/<sourceFile>.<propertyFileExtension>`. The `propertyFilePath` and `propertyFileExtension` can be customized in [application-conf/application.properties](../samples/MortgageApplication/application-conf/application.properties). For example, for the source file `epsmlist.cbl`, the process searches for an individual artifact properties file in the defined `propertyFilePath` directory. If no corresponding properties file is found, the build will use the default build values or, if any file properties were defined using the DBB file property path syntax or an alternate approach, then the build will use those.
 
-Once the `loadFileLevelProperties` property functionality is enabled, create a property file for each application artifact for which individual file properties need to be defined. For example, to override build parameters for the file `epsmlist.cbl`, create the properties file `epsmlist.cbl.properties` in the defined `propertyFilePath` folder. The name of the properties file needs to have the entire source file name including the extension, e.g. the properties file for `epsmlist.cbl` needs to be `epsmlist.cbl.properties`.
+Once the `loadFileLevelProperties` property functionality is enabled, create a properties file for each application artifact for which individual artifact properties need to be defined. For example, to override build parameters for the file `epsmlist.cbl`, create the properties file `epsmlist.cbl.properties` in the defined `propertyFilePath` folder. The name of the properties file needs to have the entire source file name including the extension; hence, the properties file for `epsmlist.cbl` needs to be named `epsmlist.cbl.properties`.
 
-The individual properties file allows you to define multiple build properties using the standard property syntax; for instance, in `epsmlist.cbl.properties`, you can define the following properties:
+The individual artifact properties file allows you to define multiple build properties using the standard property syntax. For instance, in `epsmlist.cbl.properties`, you can define the following properties:
 
 ```properties
 cobol_compileParms=LIB,SOURCE
@@ -111,18 +111,18 @@ isCICS = true
 
 With the above configuration, zAppBuild will import these properties and set them as DBB file properties.
 
-You can view a sample properties file, [epsmlist.cbl.properties](../samples/MortgageApplication/properties/epsmlist.cbl.properties), within the MortgageApplication sample.
+You can view a sample individual artifact properties file, [epsmlist.cbl.properties](../samples/MortgageApplication/properties/epsmlist.cbl.properties), within the MortgageApplication sample.
 
-**Note:** Overrides for a given build property should be managed either via the DBB file property path syntax or in the individual property files, but not both at the same time (as this can cause unpredictable behavior). The following example shows how both approaches for defining file properties can be combined to specify a set of build properties for the same source file:
+**Note:** Overrides for a given build property should be managed either via the DBB file property path syntax or in the individual artifact properties files, but not both at the same time (as this can cause unpredictable behavior). The following example shows how both approaches for defining file properties can be combined to specify a set of build properties for the same source file:
 
-- Example using the DBB file property path syntax and individual property files to define build properties for a source file named `app/cobol/AB123456.cbl`:
+- Example using the DBB file property path syntax and an individual artifact properties file to define build properties for a source file named `app/cobol/AB123456.cbl`:
   - You can use the DBB file property path syntax to define a file property for a group of files. The below defines the `deployType` for all source files in the folder cobol beginning with `AB*` to be `BATCHLOAD`:
 
     ```properties
     cobol_deployType = BATCHLOAD :: **/cobol/AB*.cbl
     ```
 
-  - At the same time, you can define an individual file property file for `app/cobol/AB123456.cbl` with the following *different* build property:
+  - At the same time, you can define an individual artifact properties file for `app/cobol/AB123456.cbl` with the following *different* build property:
 
     ```properties
     cobol_compileParms = LIB,SOURCE
@@ -130,7 +130,7 @@ You can view a sample properties file, [epsmlist.cbl.properties](../samples/Mort
 
   - During the build, the file `app/cobol/AB123456.cbl` will have the `deployType` `BATCHLOAD` and the COBOL compile parameters `LIB` and `SOURCE`.
 
-### Language Definition Mapping
+### Language definition mapping
 
 An alternative way to define build properties for a **subgroup of files** is leveraging a mapping approach. Rather than specifying individual parameters or properties for an individual application artifact, the application artifact is mapped to a language definition, which can then define multiple build parameters in a central properties file. All mapped application artifacts will inherit the defined build parameters.
 
@@ -147,7 +147,7 @@ loadLanguageDefinitionProperties = true :: **/cobol/eps*.cbl, **/cobol/lga*.cbl
 
 The Language Definition Property files need to be created in the `build-conf` folder. This will allow you to define file properties that support overriding in the Language Definition Property file. You can create multiple Language Definition Property files under `build-conf` folder to serve different variations or types. A sample Language Definition Property file can be found at [langDefProps01.properties](../build-conf/langDefProps01.properties).  
 
-The language definition property file allows you to centrally specify build properties for the group of mapped application artifacts. All mapped files will inherit the build properties. However, in the case of combining the language definition mapping with an individual property file override, the settings in the individual property file will take precedence.
+The language definition property file allows you to centrally specify build properties for the group of mapped application artifacts. All mapped files will inherit the build properties. However, in the case of combining the language definition mapping with an individual artifact properties file override, the settings in the individual artifact properties file will take precedence.
 
 In the following sample language definition, *langDefProps01.properties* is overriding the default COBOL compile parameters (`cobol_compileParms`), the file flag `isCICS`, and the linkEdit statement (`cobol_linkEditStream`):
 

--- a/samples/MortgageApplication/application-conf/README.md
+++ b/samples/MortgageApplication/application-conf/README.md
@@ -95,18 +95,10 @@ linkedit_scanLoadModule | Flag indicating to scan the load module for link depen
 linkEdit_linkEditSyslibConcatenation | A comma-separated list of libraries to be concatenated in syslib during linkEdit step | true
 
 ### languageDefinitionMapping.properties
-Sample Language Definition mapping properties used by dbb-zappbuild/utilities/BuildUtilities.groovy 
+Sample Language Definition mapping properties used by dbb-zappbuild/utilities/BuildUtilities.groovy.
 
-This contain the mapping of the files and their corresponding Language Definition properties file residing in `zAppBuild/build-conf` to override the default file properties.
+This contains the mapping of the files and their corresponding Language Definition properties files residing in `zAppBuild/build-conf` to override the default file properties.
 
 Example: The entry - `epsnbrvl.cbl=langDefProps01`, means the file properties of file `epsnbrvl.cbl` will be overridden by the properties mentioned in `zAppBuild/build-conf/langDefProps01.properties`
 
-Note: To enable Language Definition mapping, the property `loadLanguageDefinitionProperties` should be enabled in `application.properties` or in `file.properties`.  If both individual file property set by `loadFileLevelProperties` flag and language definition property is set for a file, then the individual file property will take precedence over language definition property. 
-
-The order of precedence of adding the file property is:
-  1. Individual file property 
-  2. Language Definition property 
-  3. Default file properties
-
-This will be a file property merge, i.e. if both individual file property and language definition property is set for a file, then file properties mentioned individual file property will be added to the file and those properties which are not mentioned in individual file property will be added from lower levels - Language Definition property and then from default file properties.
-
+See the [language definition mapping documentation](https://github.com/IBM/dbb-zappbuild/docs/FilePropertyManagement.md#language-definition-mapping) for more details on how to enable and use language definiton mapping.

--- a/samples/application-conf/README.md
+++ b/samples/application-conf/README.md
@@ -285,17 +285,10 @@ Property | Description | Overridable
 transfer_deployType | deployType | true
 
 ### languageDefinitionMapping.properties
-Sample Language Definition mapping properties used by dbb-zappbuild/utilities/BuildUtilities.groovy 
+Sample language definition mapping properties used by dbb-zappbuild/utilities/BuildUtilities.groovy.
 
-This contain the mapping of the files and their corresponding Language Definition properties file residing in `zAppBuild/build-conf` to override the default file properties.
+This contains the mapping of the files and their corresponding Language Definition properties files residing in `zAppBuild/build-conf` to override the default file properties.
 
 Example: The entry - `epsnbrvl.cbl=langDefProps01`, means the file properties of file `epsnbrvl.cbl` will be overridden by the properties mentioned in `zAppBuild/build-conf/langDefProps01.properties`
 
-Note: To enable Language Definition mapping, the property `loadLanguageDefinitionProperties` should be enabled in `application.properties` or in `file.properties`.  If both individual file property set by `loadFileLevelProperties` flag and language definition property is set for a file, then the individual file property will take precedence over language definition property. 
-
-The order of precedence of adding the file property is:
-  1. Individual file property 
-  2. Language Definition property 
-  3. Default file properties
-
-This will be a file property merge, i.e. if both individual file property and language definition property is set for a file, then file properties mentioned individual file property will be added to the file and those properties which are not mentioned in individual file property will be added from lower levels - Language Definition property and then from default file properties.
+See the [language definition mapping documentation](https://github.com/IBM/dbb-zappbuild/docs/FilePropertyManagement.md#language-definition-mapping) for more details on how to enable and use language definiton mapping.


### PR DESCRIPTION
The `FilePropertyManagement.md` documentation currently uses the term "individual file properties" and "individual property file" almost interchangeably. However, it is a bit confusing, because "individual file properties" sounds like we mean "file" as in "build/application artifact". But when we say "Individual property file", it sounds like we mean "file" as in the actual property file itself. This PR uses "individual artifact properties file" as a standard term.

The PR also replaces some redundant language definition mapping information in the sample README files with a link to the new documentation in `FilePropertyManagement.md`.