### PR TITLE
Additional refinements to property management documentation

### DIFF
--- a/docs/FilePropertyManagement.md
+++ b/docs/FilePropertyManagement.md
@@ -26,7 +26,7 @@ zAppBuild supports overriding the majority of build properties defined within it
 
 zAppBuild leverages DBB's API and allows you to define build parameters on three different levels for each language script:
 
-1. General defaults in the corresponding language property files: For example, you can define the compile options for building COBOL programs in [application-conf/Cobol.properties](../samples/application-conf/Cobol.properties). Property keys make use of a language prefix; for instance, COBOL property keys are prefixed with `cobol_`.
+1. General defaults in the corresponding language properties files: For example, you can define the compile options for building COBOL programs in [application-conf/Cobol.properties](../samples/application-conf/Cobol.properties). Property keys make use of a language prefix; for instance, COBOL property keys are prefixed with `cobol_`.
 2. A group definition that overrides the general default in one of two ways:
    - By using DBB's file property syntax in [application-conf/file.properties](../samples/application-conf/file.properties), and specifying the application artifact group via a pattern filter on the path name(s)
    - By mapping to a language definition file to override the defaults, such as in [application-conf/languageDefinitionMapping.properties](../samples/MortgageApplication/application-conf/languageDefinitionMapping.properties)
@@ -53,7 +53,7 @@ Default properties can be set in the corresponding language properties file. For
 
 By default, zAppBuild applies the properties stored in the [application-conf](../samples/application-conf) folder of the application repository, which allows the application team to have control over these files. These property definitions in [application-conf](../samples/application-conf) take precedence over corresponding properties defined in the [build-conf](../build-conf/) folder. If you are looking for a more centralized way to manage the default options for all applications, you can move the relevant property definitions into the zAppBuild build framework itself by taking them out of the [application-conf](../samples/application-conf) folder, and then only storing them in one of the following locations:
 
-- In the appropriate language property file(s) under [build-conf](../build-conf/)
+- In the appropriate language properties file(s) under [build-conf](../build-conf/)
 - In a separate directory within zAppBuild itself, while using the applicationConfRootDir property in [build-conf/build.properties](../build-conf/build.properties)
 
 ## Overriding properties
@@ -145,7 +145,7 @@ The "language definition mapping" approach can be enabled by setting the propert
 loadLanguageDefinitionProperties = true :: **/cobol/eps*.cbl, **/cobol/lga*.cbl
 ```
 
-Build properties for a language definition are specified in a language definition properties file, which should be created in the `build-conf` folder. You can implement multiple language definitions to serve different variations or types by creating multiple language definition properties files under the `build-conf` folder. A sample language definition properties file can be found at [langDefProps01.properties](../build-conf/langDefProps01.properties).  
+You can specify build properties for a language definition in a language definition properties file, which should be created in the `build-conf` folder. zAppBuild will import these properties from the language definition properties file and set them as DBB file properties for the mapped artifacts. You can implement multiple language definitions to serve different variations or types by creating multiple language definition properties files under the `build-conf` folder. A sample language definition properties file can be found at [langDefProps01.properties](../build-conf/langDefProps01.properties).  
 
 A language definition properties file allows you to centrally specify build properties for the group of mapped application artifacts. All mapped files will inherit those build properties. However, in the case of combining the language definition mapping with an individual artifact properties file override, for any build property that is defined in both places, the property definition in the individual artifact properties file will take precedence and be applied. Properties that are not specified in the individual artifact properties file will be defined by lower precedence strategies - that is, from the language definition mapping if defined there, or if not, then from the default properties.
 
@@ -167,8 +167,6 @@ To map files to a language definition, create a `languageDefinitionMapping.prope
   ```
 
 See [languageDefinitionMapping.properties](../samples/MortgageApplication/application-conf/languageDefinitionMapping.properties) for a sample language definition mapping file.
-
-This language definition mapping implementation again leverages DBB's file property concept to define these settings only for the mapped files.
 
 [^1]: DBB is managing the DBB file properties in its separate internal table compared to the default properties. This table leverages the combination of [property name + file pattern] as the key of the internal table. When the same key is declared a second time, it overrides the first one.
 [^2]: Because of managing DBB file properties is done in a single table, you can experience unpredictable behaviour when mixing qualified file path pattern definitions and file path patterns containing wildcards for the same property name.

--- a/docs/FilePropertyManagement.md
+++ b/docs/FilePropertyManagement.md
@@ -12,9 +12,9 @@
 
 ## Introduction
 
-Building mainframe application programs requires configuring various parameters and options for the different build steps, such as the pre-compile, compile, or link-edit step. For example, an application can contain COBOL programs that need to be link edited with the option `NCAL` or without the option `NCAL` for different purposes. An override may be required for any build parameter for the various build steps like compile parameters, bind parameters, link edit parameters, and so on.
+This document explains how to define compiler and other options when building a program or subset of programs with zAppBuild. Building mainframe application programs requires configuring various parameters and options for the different build steps, such as the pre-compile, compile, or link-edit step. For example, an application can contain COBOL programs that need to be link edited with the option `NCAL` or without the option `NCAL` for different purposes. An override may be required for any build parameter for the various build steps like compile parameters, bind parameters, link edit parameters, and so on.
 
-In existing mainframe toolchains, this customization is performed by assigning a type to the application artifact. This *type* is often used to specify the build parameters and options for an entire **subgroup** of application artifacts. Additionally, it allows that an application program might have some individual overrides as well.
+In existing mainframe toolchains, this customization is performed by assigning a type to the application artifact[^1]. This *type* is often used to specify the build parameters and options for an entire **subgroup** of application artifacts. Additionally, it allows that an application program might have some individual overrides as well.
 
 Generally, each build parameter for an application artifact will either have a default value or an override of the default value.
 
@@ -38,9 +38,9 @@ zAppBuild comes with various build property strategies that can be combined via 
 
 |Precedence|Strategy|Use case|Implementation|
 |-|-|-|-|
-|1.|Individual artifact properties file|Override one or multiple build parameters for individual files|DBB file property defining an override for the specific file[^1]|
-|2.|Language definition mapping|Override and define one or multiple build parameters for a group of mapped application artifacts|DBB file property defining an override for the specific file(s)[^1]|
-|3.|DBB file properties|Override a single build parameter for individual files or a grouped list of application artifacts|DBB file property defining an override for the specific[^1]  or grouped list[^2] of application artifacts|
+|1.|Individual artifact properties file|Override one or multiple build parameters for individual files|DBB file property defining an override for the specific file[^2]|
+|2.|Language definition mapping|Override and define one or multiple build parameters for a group of mapped application artifacts|DBB file property defining an override for the specific file(s)[^2]|
+|3.|DBB file properties|Override a single build parameter for individual files or a grouped list of application artifacts|DBB file property defining an override for the specific[^2]  or grouped list[^3] of application artifacts|
 |4.|Default properties|General build properties used when no overrides are defined|Build property defining the default value for all files|
 
 To understand the order of precedence, think of this as a merge of the property configurations. For example, if both an individual artifact properties file and a language definition mapping are configured for a file, then the properties defined through the individual artifact properties file take precedence, but are also merged with other properties defined by the language definition mapping and the default properties.
@@ -168,5 +168,6 @@ To map files to a language definition, create a `languageDefinitionMapping.prope
 
 See [languageDefinitionMapping.properties](../samples/MortgageApplication/application-conf/languageDefinitionMapping.properties) for a sample language definition mapping file.
 
-[^1]: DBB is managing the DBB file properties in its separate internal table compared to the default properties. This table leverages the combination of [property name + file pattern] as the key of the internal table. When the same key is declared a second time, it overrides the first one.
-[^2]: Because of managing DBB file properties is done in a single table, you can experience unpredictable behaviour when mixing qualified file path pattern definitions and file path patterns containing wildcards for the same property name.
+[^1]: The term "artifact" and "file" in this document refer to program source code that will built (as opposed to JCL or other non-buildable items), for example by DBB.
+[^2]: DBB is managing the DBB file properties in its separate internal table compared to the default properties. This table leverages the combination of [property name + file pattern] as the key of the internal table. When the same key is declared a second time, it overrides the first one.
+[^3]: Because of managing DBB file properties is done in a single table, you can experience unpredictable behaviour when mixing qualified file path pattern definitions and file path patterns containing wildcards for the same property name.

--- a/samples/MortgageApplication/application-conf/application.properties
+++ b/samples/MortgageApplication/application-conf/application.properties
@@ -45,9 +45,9 @@ skipImpactCalculationList=
 
 # ### Properties to enable and configure build property overrides using individual artifact properties files
 
-# flag to enable the zAppBuild capability to load individual artifact properties files for individual source files, 
-# Note: To activate the loading of property files for a group of files, it is recommended to use the file property path
-# syntax instead. (i.e. loadFileLevelProperties=true :: **/cobol/*.cbl to enable it for all cobol files)
+# flag to enable the zAppBuild capability to load individual artifact properties files for all individual source files. 
+# Note: To only activate loadFileLevelProperties for a group of files, it is recommended to use DBB's file property path
+# syntax in application-conf/file.properties instead.
 # default: false
 loadFileLevelProperties=false
 
@@ -55,8 +55,8 @@ loadFileLevelProperties=false
 # file - languageDefinitionMapping.properties
 # If loadFileLevelProperties is set as true above, the properties from the individual artifact properties files will override the 
 # properties from language definition properties file.
-# Note: To activate the loading of property files for a group of files, it is recommended to use the file property path
-# syntax instead. (i.e. loadLanguageDefinitionProperties=true :: **/cobol/*.cbl to enable it for all cobol files)
+# Note: To only activate loadLanguageDefinitionProperties for a group of files, it is recommended to use DBB's file property path
+# syntax in application-conf/file.properties instead.
 loadLanguageDefinitionProperties=false
 
 # relative path to folder containing individual artifact properties files

--- a/samples/MortgageApplication/application-conf/file.properties
+++ b/samples/MortgageApplication/application-conf/file.properties
@@ -40,5 +40,4 @@ loadFileLevelProperties = true :: **/cobol/epsmlist.cbl
 # Example 1: Enable language definition mapping for all COBOL files: loadLanguageDefinitionProperties=true :: **/cobol/*.cbl
 # Example 2: The following file path pattern looks for a language definition properties file mapping for epsnbrvl.cbl and epsmpmt.cbl 
 # in the application-conf/languageDefinitionMapping.properties file:
-
-loadLanguageDefinitionProperties = true :: **/cobol/epsnbrvl.cbl, **/cobol/epsmpmt.cbl  
+loadLanguageDefinitionProperties = true :: **/cobol/epsnbrvl.cbl, **/cobol/epsmpmt.cbl

--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -64,8 +64,8 @@ jobCard=
 
 # ### Properties to enable and configure build property overrides using individual artifact properties files
 
-# flag to enable the zAppBuild capability to load individual artifact properties files for individual source files. 
-# Note: To activate the loading of property files for a group of files, it is recommended to use DBB's file property path
+# flag to enable the zAppBuild capability to load individual artifact properties files for all individual source files. 
+# Note: To only activate loadFileLevelProperties for a group of files, it is recommended to use DBB's file property path
 # syntax in application-conf/file.properties instead.
 # default: false
 loadFileLevelProperties=false
@@ -74,7 +74,7 @@ loadFileLevelProperties=false
 # file - languageDefinitionMapping.properties
 # If loadFileLevelProperties is set as true above, the properties from the individual artifact properties files will override the 
 # properties from language definition properties file.
-# Note: To activate the loading of property files for a group of files, it is recommended to use DBB's file property path
+# Note: To only activate loadLanguageDefinitionProperties for a group of files, it is recommended to use DBB's file property path
 # syntax in application-conf/file.properties instead.
 loadLanguageDefinitionProperties=false
 


### PR DESCRIPTION
- Add in Nelson's suggestions about intro sentence and "artifact"/"file" terminology clarifications
- Move language definition properties implementation detail from the end of the document
- Move `file.properties` examples from `application.properties` to `file.properties`
- Minor copyediting